### PR TITLE
Fixed #13. A small inversion of logic was the root cause.

### DIFF
--- a/SlidingDrawer/slidingdrawer/src/main/java/hollowsoft/slidingdrawer/SlidingDrawer.java
+++ b/SlidingDrawer/slidingdrawer/src/main/java/hollowsoft/slidingdrawer/SlidingDrawer.java
@@ -1069,7 +1069,7 @@ public class SlidingDrawer extends ViewGroup {
         @Override
         public void onClick(final View view) {
 
-            if (locked) {
+            if (!locked) {
 
                 if (animateOnClick) {
                     animateToggle();


### PR DESCRIPTION
This private inner class was mistreating the `locked` boolean and instead animating the drawer when it shouldn't have.